### PR TITLE
refactor: jwt 버전 수정 및 pyjwt 제외_250909

### DIFF
--- a/myapi/settings.py
+++ b/myapi/settings.py
@@ -208,21 +208,24 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 
 
+from datetime import timedelta
+
 REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated",],
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework_simplejwt.authentication.JWTAuthentication",
-        #"rest_framework.authentication.SessionAuthentication",
     ],
 }
 
-JWT_AUTH = {
-    "JWT_SECRET_KEY": SECRET_KEY, 
-    "JWT_ALGORITHM": "HS256", # 암호화 알고리즘
-    "JWT_ALLOW_REFRESH": True,
-    "JWT_EXPIRATION_DELTA": timedelta(days=7), # 유효기간
-    "JWT_REFRESH_EXPIRATION_DELTA": timedelta(days=28), # JWT 토큰 갱신 유효기간
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(days=7),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=28),
+    "ROTATE_REFRESH_TOKENS": False,
+    "BLACKLIST_AFTER_ROTATION": True,
+    "AUTH_HEADER_TYPES": ("Bearer",),
+    "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.AccessToken",),
 }
+
 
 #smtp
 #이메일 인증
@@ -262,6 +265,8 @@ fcm_dict_str = os.getenv("FCM_CREDENTIALS_DICT", None)
 if fcm_dict_str:
     try:
         FCM_CREDENTIALS_DICT = json.loads(fcm_dict_str)
+        if "private_key" in FCM_CREDENTIALS_DICT:
+            FCM_CREDENTIALS_DICT["private_key"] = FCM_CREDENTIALS_DICT["private_key"].replace("\\n", "\n")  # ✅ 줄바꿈 복원
     except json.JSONDecodeError:
         FCM_CREDENTIALS_DICT = None
 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Django==3.2.25
 django-cors-headers==4.1.0
 django-environ==0.11.2
 djangorestframework==3.15.1
-djangorestframework-jwt==1.11.0
+# djangorestframework-jwt==1.11.0
 djangorestframework-simplejwt==5.3.0
 gunicorn==23.0.0
 mysqlclient==2.1.1  # MySQL 사용 시 필요
@@ -17,7 +17,7 @@ seaborn==0.12.2
 mplfinance==0.12.10b0  # 주식 차트 시각화 관련
 sqlparse==0.4.4
 whitenoise==6.5.0
-PyJWT==1.7.1
+PyJWT==2.8.0
 PyYAML==6.0
 PyQt5<5.15.10
 elasticsearch==8.5.2  # 벡터 검색 관련


### PR DESCRIPTION
### 변경 목적
- firebase-admin에서 요구하는 PyJWT 버전(>=2.5.0)과 기존 djangorestframework-jwt (PyJWT<2.0.0) 간의 충돌 발생
- 기존 사용하던 `djangorestframework-jwt`는 유지보수 중단됨
- 이를 해결하기 위해 `simplejwt`를 공식 JWT 인증 시스템으로 채택하고 설정 정비함

---

### 주요 변경사항
- `djangorestframework-jwt==1.11.0` 삭제
- `PyJWT==1.7.1` 삭제 → `PyJWT==2.8.0`으로 업그레이드
- `firebase-admin==6.4.0` 유지
- `settings.py`:
  - `JWT_AUTH` 설정 제거
  - `SIMPLE_JWT` 설정 추가
  - `DEFAULT_AUTHENTICATION_CLASSES`에 `JWTAuthentication` 적용 확인
- `requirements.txt` 정비

---

### 영향 범위
- 로그인/회원가입/토큰 인증 기능은 모두 `simplejwt` 기반으로 전환됨
- 기존 JWT 발급 방식과 호환되지 않음 → 토큰 발급 및 검증 API 테스트 필요
- Firebase 푸시 알림 기능은 PyJWT 충돌 없이 정상 작동 가능

---

### 테스트
- 로컬에서 회원가입 및 로그인 API 정상 작동 확인
- FCM 푸시 알림 정상 동작 확인
